### PR TITLE
Parawelt auch im "kurz"-Modus erkennen

### DIFF
--- a/krrrcks.xml
+++ b/krrrcks.xml
@@ -252,6 +252,7 @@ resetFormat()</script>
                 <colorTriggerBgColor>#000000</colorTriggerBgColor>
                 <regexCodeList>
                     <string>^(.*)Du bist hier im Innern einer (.*) schimmernden Kugel,$</string>
+                    <string>^(.*)Im Innern einer (.*) schimmernden Kugel.$</string>
                 </regexCodeList>
                 <regexCodePropertyList>
                     <integer>1</integer>

--- a/krrrcks.xml
+++ b/krrrcks.xml
@@ -256,6 +256,7 @@ resetFormat()</script>
                 </regexCodeList>
                 <regexCodePropertyList>
                     <integer>1</integer>
+                    <integer>1</integer>
                 </regexCodePropertyList>
             </Trigger>
         </TriggerGroup>


### PR DESCRIPTION
Wenn man nicht die Langbeschreibung der Räume sieht, greift der bisherige Trigger nicht. Mit diesem Fix wird auch die Kurzbeschreibung ausreichen, um ME.para korrekt umzustellen.
